### PR TITLE
#52 : The Callback Event Message Box sample opens the dialog on all browsers instances

### DIFF
--- a/common/message-box/callback-event/Controls/MessageBox/MessageBoxContainer.razor
+++ b/common/message-box/callback-event/Controls/MessageBox/MessageBoxContainer.razor
@@ -45,6 +45,9 @@
 
     #region Variables
 
+    [Inject]
+    public MessageBoxService MessageBoxService { get; set; }
+
     public string Title { get; set; }
     public string Message { get; set; }
     public MessageBoxButtonTypeEnum ButtonType { get; set; }

--- a/common/message-box/callback-event/Controls/MessageBox/MessageBoxService.cs
+++ b/common/message-box/callback-event/Controls/MessageBox/MessageBoxService.cs
@@ -4,7 +4,7 @@ namespace MessageBoxControl.Controls.MessageBox
 {
     public class MessageBoxService
     {
-        public static event Action<string, string, MessageBoxButtonTypeEnum, Action<MessageBoxResultEnum>> OnShowMessageBox;
+        public event Action<string, string, MessageBoxButtonTypeEnum, Action<MessageBoxResultEnum>> OnShowMessageBox;
 
         public void Show(string title, string message, MessageBoxButtonTypeEnum buttonType, Action<MessageBoxResultEnum> actionToInvoke)
         {


### PR DESCRIPTION
This pull request corrects the #52 issue due to the use of the static keyword in MessageBoxService

`public static event Action<string, string, MessageBoxButtonTypeEnum, Action<MessageBoxResultEnum>> OnShowMessageBox;`