### PR TITLE
chore(tilelayout): fixed clickable element

### DIFF
--- a/tilelayout/add-remove-tiles/AddRemoveTiles/Pages/Index.razor
+++ b/tilelayout/add-remove-tiles/AddRemoveTiles/Pages/Index.razor
@@ -32,7 +32,7 @@
                                                 <span>
                                                     @item.Title
                                                 </span>
-                                                <span>
+                                                <span onpointerdown="stopPropagation(event)">
                                                     <TelerikButton Icon="close" Title="Delete tile" Class="k-flat" OnClick="@(() => Remove(item))"></TelerikButton>
                                                 </span>
                                             </div>
@@ -72,6 +72,12 @@
 
     </SplitterPanes>
 </TelerikSplitter>
+
+<script suppress-error="BL9992">
+  window.stopPropagation = (e) => {
+    e.stopPropagation();
+  }
+</script>
 
 @code {
     public IEnumerable<PodcastViewModel> Podcasts { get; set; }

--- a/tilelayout/add-remove-tiles/AddRemoveTiles/Pages/Index.razor
+++ b/tilelayout/add-remove-tiles/AddRemoveTiles/Pages/Index.razor
@@ -32,6 +32,7 @@
                                                 <span>
                                                     @item.Title
                                                 </span>
+                                                @*The JS script is in the "_Host.cshtml" file*@
                                                 <span onpointerdown="stopPropagation(event)">
                                                     <TelerikButton Icon="close" Title="Delete tile" Class="k-flat" OnClick="@(() => Remove(item))"></TelerikButton>
                                                 </span>
@@ -72,12 +73,6 @@
 
     </SplitterPanes>
 </TelerikSplitter>
-
-<script suppress-error="BL9992">
-  window.stopPropagation = (e) => {
-    e.stopPropagation();
-  }
-</script>
 
 @code {
     public IEnumerable<PodcastViewModel> Podcasts { get; set; }

--- a/tilelayout/add-remove-tiles/AddRemoveTiles/Pages/_Host.cshtml
+++ b/tilelayout/add-remove-tiles/AddRemoveTiles/Pages/_Host.cshtml
@@ -35,7 +35,7 @@
     @*draggable event in HeaderTemplate*@
     <script>
         window.stopPropagation = (e) => {
-        e.stopPropagation();
+            e.stopPropagation();
         }
     </script>
 </body>

--- a/tilelayout/add-remove-tiles/AddRemoveTiles/Pages/_Host.cshtml
+++ b/tilelayout/add-remove-tiles/AddRemoveTiles/Pages/_Host.cshtml
@@ -30,5 +30,13 @@
     </div>
 
     <script src="_framework/blazor.server.js"></script>
+
+    @*Necessary to avoid mix up with clickable and*@
+    @*draggable event in HeaderTemplate*@
+    <script>
+        window.stopPropagation = (e) => {
+        e.stopPropagation();
+        }
+    </script>
 </body>
 </html>


### PR DESCRIPTION
- Added stop propagation of the container wrapping the clickable elements in the HeaderTemplate of the tiles. 
- Related to this [FR](https://feedback.telerik.com/blazor/1553733-prevent-tilelayout-from-stopping-the-click-event-in-the-tile-header)
