### PR TITLE
testing example improvements

### DIFF
--- a/testing/bUnit-justmock/Telerik.Blazor.BUnit.JustMock.sln
+++ b/testing/bUnit-justmock/Telerik.Blazor.BUnit.JustMock.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30626.31
+# Visual Studio Version 17
+VisualStudioVersion = 17.1.32407.343
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Telerik.Blazor.BUnit.JustMock", "Telerik.Blazor.BUnit.JustMock\Telerik.Blazor.BUnit.JustMock.csproj", "{4C10E17C-5E60-4B04-B6D9-6DCD4776BC62}"
 EndProject

--- a/testing/bUnit-justmock/Telerik.Blazor.BUnit.JustMock/DemoSample/DialogPage.cs
+++ b/testing/bUnit-justmock/Telerik.Blazor.BUnit.JustMock/DemoSample/DialogPage.cs
@@ -1,0 +1,23 @@
+﻿using Bunit;
+using BUnit_Sample.Pages;
+using Telerik.Blazor.BUnit.JustMock.Common;
+using Xunit;
+
+namespace Telerik.Blazor.BUnit.JustMock
+{
+    public class DialogPage : TelerikTestContextWithActualRoot
+    {    
+        [Fact]
+        public void Dialog_alert_triggered_on_button_click()
+        {
+            _ = RenderComponent<Dialog>();
+
+            var button = this.RootComponent.Find("button[id=\"dialog-show-button\"]");
+
+            button.Click();
+
+            Assert.Contains("Something went wrong!", this.RootComponent.Markup);
+        }
+    }
+}
+

--- a/testing/bUnit-justmock/Telerik.Blazor.BUnit.JustMock/DemoSample/WindowButtonPage.cs
+++ b/testing/bUnit-justmock/Telerik.Blazor.BUnit.JustMock/DemoSample/WindowButtonPage.cs
@@ -10,7 +10,7 @@ namespace Telerik.Blazor.BUnit.JustMock
         [Fact]
         public void Button_in_window_is_rendered()
         {
-            RenderComponent<Window_Button>();
+            _ = RenderComponent<Window_Button>();
 
             var button = this.RootComponent.Find("button[id=\"window-test-button\"]");
             
@@ -20,7 +20,7 @@ namespace Telerik.Blazor.BUnit.JustMock
         [Fact]
         public void Button_in_window_click_action()
         {
-            RenderComponent<Window_Button>();
+            _ = RenderComponent<Window_Button>();
 
             var button = this.RootComponent.Find("button[id=\"window-test-button\"]");
 

--- a/testing/bUnit-justmock/Telerik.Blazor.BUnit.JustMock/Telerik.Blazor.BUnit.JustMock.csproj
+++ b/testing/bUnit-justmock/Telerik.Blazor.BUnit.JustMock/Telerik.Blazor.BUnit.JustMock.csproj
@@ -1,21 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="bunit.web" Version="1.0.0-preview-01" />
-    <PackageReference Include="JustMock" Version="2021.1.115.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="bunit.web" Version="1.6.4" />
+    <PackageReference Include="JustMock" Version="2022.1.223.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -23,7 +23,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\testing-sample-app\BUnit_Sample\BUnit_Sample.csproj" />
-    <PackageReference Include="Telerik.UI.for.Blazor" Version="2.22.0" />
+    <PackageReference Include="Telerik.UI.for.Blazor" Version="3.1.0" />
   </ItemGroup>
 
 </Project>

--- a/testing/readme.md
+++ b/testing/readme.md
@@ -16,13 +16,15 @@ In this collection of sample projects, the application under test is in the `tes
 
 In the code of your tests:
 
-* Initialize the Telerik components as described above. In these sample projects, that scaffolding is done in `TelerikTestContext` - this is a class your test classes can inherit from which takes care of setting up the services and the root component.
+* Initialize the Telerik components as described above. In these sample projects, that scaffolding is done in two different classes: `TelerikTestContext`, and `TelerikTestContextWithActualRoot` - these are classes that your test classes can inherit from which takes care of setting up the services and the root component. Both of these classes inherit the standard `TestContext of the `bUnit` framework and override its rendering methods to ensure there is a Telerik root component first. Their constructors initializes the services. If you don't inherit such a class, you need  to do that scaffolding yourself before starting a test, and you need to add components under test to the Telerik Root Component.
 
-    * This class inherits the standard `TestContext` of the `bUnit` framework and overrides its rendering methods to ensure there is a Telerik root component first. Its constructor initializes the services. If you don't inherit such a class, you need  to do that scaffolding yourself before starting a test, and you need to add components under test to the Telerik Root Component.
+    The difference between the two is the following:
+    * `TelerikTestContext` is the go-to option, as it adds a CascadingValue of type `TelerikRootComponent` to the bUnit's `RenderTree`. This approach does not include and cannot depend on any logic contained within the `TelerikRootComponent`. 
+    * `TelerikTestContextWithActualRoot` introduces an actual instance of the `TelerikRootComponent`, which wraps the component you are currently testing/rendering. This approach is useful for scenarios where your test would depend on logic contained within the `TelerikRootComponent`, like integrating a test that depends on the `DialogFactory` cascading value, which is propagated from the Telerik Root Component. 
 
 * Add components under test to the standard render tree as with other components you test.
 
-* For popup components (such as the Window or Tooltip, or the dropdowns), look for their content inside the `TelerikRootComponent`, not in the place of declaration. In this sample, the field is called `RootComponent` and comes from the base class (`TelerikTestContext`).
+* For popup components (such as the Window or Tooltip, or the dropdowns), look for their content inside the `TelerikRootComponent`, not in the place of declaration. In this sample, the field is called `RootComponent` and comes from the base class (`TelerikTestContext` or `TelerikTestContextWithActualRoot`).
 
     * Such popups render their DOM elements only when they are shown because that optimizes the performance of the Blazor app. Opening them and interacting with the new DOM that is created may require an e2e test rather than a unit test (see below).
 

--- a/testing/testing-sample-app/BUnit_Sample/BUnit_Sample.csproj
+++ b/testing/testing-sample-app/BUnit_Sample/BUnit_Sample.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Telerik.UI.for.Blazor" Version="2.22.0" />
+    <PackageReference Include="Telerik.UI.for.Blazor" Version="3.1.0" />
   </ItemGroup>
   
 </Project>

--- a/testing/testing-sample-app/BUnit_Sample/Pages/Dialog.razor
+++ b/testing/testing-sample-app/BUnit_Sample/Pages/Dialog.razor
@@ -1,0 +1,23 @@
+﻿@page "/dialog"
+
+<TelerikButton Id="dialog-show-button" OnClick="@ShowAlert">Show Alert</TelerikButton>
+<TelerikButton OnClick="@ShowAlertWithTitle">Show Alert with Custom Title</TelerikButton>
+
+@code {
+    [CascadingParameter]
+    public DialogFactory Dialogs { get; set; }
+
+    public async Task ShowAlert()
+    {
+        await Dialogs.AlertAsync("Something went wrong!");
+
+        Console.WriteLine("The user dismissed the alert box.");
+    }
+
+    async Task ShowAlertWithTitle()
+    {
+        await Dialogs.AlertAsync("Something went wrong!", "Read this!");
+
+        Console.WriteLine("The user dismissed the alert box with the custom title.");
+    }
+}

--- a/testing/testing-sample-app/BUnit_Sample/Pages/Window_Button.razor
+++ b/testing/testing-sample-app/BUnit_Sample/Pages/Window_Button.razor
@@ -1,5 +1,7 @@
 ﻿@page "/button-window-integration"
 
+<p>Some random content</p>
+
 <TelerikWindow Visible="true">
     <WindowTitle>
         Window


### PR DESCRIPTION
- bumps package and framework versions
- introduces a second, optional way, of adding a `TelerikRootFragment` to the TestContext so one can write tests that depend on logic contained with it(ex. PredefinedDialog).