### PR TITLE
chore(hybrid-apps):unify the service registration as in our getting started resources

### DIFF
--- a/common/hybrid-blazor-apps/BlazorMauiApp/MauiProgram.cs
+++ b/common/hybrid-blazor-apps/BlazorMauiApp/MauiProgram.cs
@@ -16,6 +16,8 @@ namespace BlazorMauiApp
                 });
 
             builder.Services.AddMauiBlazorWebView();
+
+            builder.Services.AddTelerikBlazor();
 #if DEBUG
             builder.Services.AddBlazorWebViewDeveloperTools();
 #endif

--- a/common/hybrid-blazor-apps/BlazorMauiApp/_Imports.razor
+++ b/common/hybrid-blazor-apps/BlazorMauiApp/_Imports.razor
@@ -11,7 +11,6 @@
 
 @using Telerik.Blazor
 @using Telerik.Blazor.Components
-@using Telerik.Blazor.Services
 
 @using Telerik.DataSource
 @using Telerik.DataSource.Extensions

--- a/common/hybrid-blazor-apps/BlazorWinFormsApp/Program.cs
+++ b/common/hybrid-blazor-apps/BlazorWinFormsApp/Program.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -25,7 +26,17 @@ namespace BlazorWinFormsApp
             Application.SetHighDpiMode(HighDpiMode.SystemAware);
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
+
+            var services = new ServiceCollection();
+
+            ConfigureServices(services);
+
             Application.Run(new Form1());
+        }
+
+        private static void ConfigureServices(ServiceCollection services)
+        {
+            services.AddTelerikBlazor();
         }
     }
 }

--- a/common/hybrid-blazor-apps/BlazorWinFormsApp/_Imports.razor
+++ b/common/hybrid-blazor-apps/BlazorWinFormsApp/_Imports.razor
@@ -8,7 +8,6 @@
 
 @using Telerik.Blazor
 @using Telerik.Blazor.Components
-@using Telerik.Blazor.Services
 
 @using Telerik.DataSource
 @using Telerik.DataSource.Extensions

--- a/common/hybrid-blazor-apps/BlazorWpfApp/App.xaml.cs
+++ b/common/hybrid-blazor-apps/BlazorWpfApp/App.xaml.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Windows;
 
@@ -17,6 +18,15 @@ namespace BlazorWpfApp
             {
                 MessageBox.Show(error.ExceptionObject.ToString(), "Error", MessageBoxButton.OK, MessageBoxImage.Error);
             };
+
+            var services = new ServiceCollection();
+
+            ConfigureServices(services);
+        }
+
+        private static void ConfigureServices(ServiceCollection services)
+        {
+            services.AddTelerikBlazor();
         }
     }
 }

--- a/common/hybrid-blazor-apps/BlazorWpfApp/_Imports.razor
+++ b/common/hybrid-blazor-apps/BlazorWpfApp/_Imports.razor
@@ -12,7 +12,6 @@
 
 @using Telerik.Blazor
 @using Telerik.Blazor.Components
-@using Telerik.Blazor.Services
 
 @using Telerik.DataSource
 @using Telerik.DataSource.Extensions


### PR DESCRIPTION
The update affects all three apps

- Remove `@using Telerik.Blazor.Services` from the `_Imports` - it is not needed and it may confuse clients as it is different than the step suggested [here](https://docs.telerik.com/blazor-ui/getting-started/what-you-need#common-configuration)

- Register the Telerik service - similar to [this step](https://docs.telerik.com/blazor-ui/getting-started/what-you-need#client-side-project-specifics)