### PR TITLE
Update sample apps to NET7

### DIFF
--- a/sample-applications/blazing-coffee/BlazingCoffee/Client/BlazingCoffee.Client.csproj
+++ b/sample-applications/blazing-coffee/BlazingCoffee/Client/BlazingCoffee.Client.csproj
@@ -20,14 +20,14 @@
 
   <ItemGroup>
     <PackageReference Include="Blazored.LocalStorage" Version="4.1.5" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.0-rc.2.22476.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="7.0.0-rc.2.22476.2" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="7.0.0-rc.2.22476.2" />
-    <PackageReference Include="Microsoft.Extensions.Localization" Version="7.0.0-rc.2.22476.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="7.0.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Localization" Version="7.0.0" />
     <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="2.1.113" />
-    <PackageReference Include="System.Net.Http.Json" Version="7.0.0-rc.2.22472.3" />
+    <PackageReference Include="System.Net.Http.Json" Version="7.0.0" />
     <PackageReference Include="Telerik.UI.for.Blazor.Trial" Version="3.6.1" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0-rc.2.22472.3" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
 	  <PackageReference Include="Markdig" Version="0.26.0" />
   </ItemGroup>
 

--- a/sample-applications/blazing-coffee/BlazingCoffee/Client/BlazingCoffee.Client.csproj
+++ b/sample-applications/blazing-coffee/BlazingCoffee/Client/BlazingCoffee.Client.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <!-- PWA -->
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
     <!-- /PWA -->
@@ -20,14 +20,14 @@
 
   <ItemGroup>
     <PackageReference Include="Blazored.LocalStorage" Version="4.1.5" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="6.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="6.0.1" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Localization" Version="6.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.0-rc.2.22476.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="7.0.0-rc.2.22476.2" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="7.0.0-rc.2.22476.2" />
+    <PackageReference Include="Microsoft.Extensions.Localization" Version="7.0.0-rc.2.22476.2" />
     <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="2.1.113" />
-    <PackageReference Include="System.Net.Http.Json" Version="6.0.0" />
+    <PackageReference Include="System.Net.Http.Json" Version="7.0.0-rc.2.22472.3" />
     <PackageReference Include="Telerik.UI.for.Blazor.Trial" Version="3.6.1" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0-rc.2.22472.3" />
 	  <PackageReference Include="Markdig" Version="0.26.0" />
   </ItemGroup>
 

--- a/sample-applications/blazing-coffee/BlazingCoffee/Server/BlazingCoffee.Server.csproj
+++ b/sample-applications/blazing-coffee/BlazingCoffee/Server/BlazingCoffee.Server.csproj
@@ -10,12 +10,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="7.0.0-rc.2.22476.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="7.0.0-rc.2.22476.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="7.0.0-rc.2.22476.2" />
-    <PackageReference Include="Microsoft.AspNetCore.ApiAuthorization.IdentityServer" Version="7.0.0-rc.2.22476.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.0-rc.2.22472.11" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.0-rc.2.22472.11">   
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="7.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="7.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="7.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.ApiAuthorization.IdentityServer" Version="7.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.0">   
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -27,13 +27,13 @@
 
   <ItemGroup>
     <PackageReference Include="CsvHelper" Version="16.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="7.0.0-rc.2.22476.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.0-rc.2.22472.11" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.0-rc.2.22472.11">
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="7.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="7.0.0-rc.2.22510.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="7.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
     <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="6.0.0" />
     <PackageReference Include="Telerik.Documents.SpreadsheetStreaming.Trial" Version="2022.3.906" />

--- a/sample-applications/blazing-coffee/BlazingCoffee/Server/BlazingCoffee.Server.csproj
+++ b/sample-applications/blazing-coffee/BlazingCoffee/Server/BlazingCoffee.Server.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <UserSecretsId>BlazingCoffee.Server-EE526336-C312-404E-8393-993CE0300831</UserSecretsId>
   </PropertyGroup>
 
@@ -10,12 +10,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="6.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="6.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.ApiAuthorization.IdentityServer" Version="6.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.1">
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="7.0.0-rc.2.22476.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="7.0.0-rc.2.22476.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="7.0.0-rc.2.22476.2" />
+    <PackageReference Include="Microsoft.AspNetCore.ApiAuthorization.IdentityServer" Version="7.0.0-rc.2.22476.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.0-rc.2.22472.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.0-rc.2.22472.11">   
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -27,13 +27,13 @@
 
   <ItemGroup>
     <PackageReference Include="CsvHelper" Version="16.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="6.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.1">
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="7.0.0-rc.2.22476.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.0-rc.2.22472.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.0-rc.2.22472.11">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="7.0.0-rc.2.22510.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
     <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="6.0.0" />
     <PackageReference Include="Telerik.Documents.SpreadsheetStreaming.Trial" Version="2022.3.906" />

--- a/sample-applications/blazing-coffee/BlazingCoffee/Shared/BlazingCoffee.Shared.csproj
+++ b/sample-applications/blazing-coffee/BlazingCoffee/Shared/BlazingCoffee.Shared.csproj
@@ -5,9 +5,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="7.0.0-rc.2.22476.2" />
+    <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="7.0.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="6.0.0-preview.4.21253.7" />
-    <PackageReference Include="System.Text.Json" Version="7.0.0-rc.2.22472.3" />
+    <PackageReference Include="System.Text.Json" Version="7.0.0" />
     <PackageReference Include="Telerik.UI.for.Blazor.Trial" Version="3.6.1" />
   </ItemGroup>
 

--- a/sample-applications/blazing-coffee/BlazingCoffee/Shared/BlazingCoffee.Shared.csproj
+++ b/sample-applications/blazing-coffee/BlazingCoffee/Shared/BlazingCoffee.Shared.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="7.0.0-rc.2.22476.2" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="6.0.0-preview.4.21253.7" />
-    <PackageReference Include="System.Text.Json" Version="6.0.0" />
+    <PackageReference Include="System.Text.Json" Version="7.0.0-rc.2.22472.3" />
     <PackageReference Include="Telerik.UI.for.Blazor.Trial" Version="3.6.1" />
   </ItemGroup>
 

--- a/sample-applications/blazing-coffee/global.json
+++ b/sample-applications/blazing-coffee/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.100-rc.2",
+    "version": "7.0.0",
     "rollForward": "latestFeature"
   }
 }

--- a/sample-applications/blazing-coffee/global.json
+++ b/sample-applications/blazing-coffee/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.100",
+    "version": "7.0.100-rc.2",
     "rollForward": "latestFeature"
   }
 }

--- a/sample-applications/blazing-coffee/readme.md
+++ b/sample-applications/blazing-coffee/readme.md
@@ -77,9 +77,9 @@ The current demo app includes examples of the following features in the Blazor W
 
 ## Requirements
 
-- .NET 6
-- Telerik UI for Blazor (Trial or Commercial)
-- NPM (Node Package Manager for SASS themes)(optional)
+- [.NET 6](https://dotnet.microsoft.com/en-us/download/dotnet/7.0)
+- [Telerik UI for Blazor](https://www.telerik.com/blazor-ui) (Trial or Commercial)
+- [npm](https://www.npmjs.com/) (node package manager, for sass themes)
 
 ## Running the sample Blazor project
 

--- a/sample-applications/blazing-coffee/readme.md
+++ b/sample-applications/blazing-coffee/readme.md
@@ -77,7 +77,7 @@ The current demo app includes examples of the following features in the Blazor W
 
 ## Requirements
 
-- [.NET 6](https://dotnet.microsoft.com/en-us/download/dotnet/7.0)
+- [.NET 7](https://dotnet.microsoft.com/en-us/download/dotnet/7.0)
 - [Telerik UI for Blazor](https://www.telerik.com/blazor-ui) (Trial or Commercial)
 - [npm](https://www.npmjs.com/) (node package manager, for sass themes)
 

--- a/sample-applications/blazor-dashboard/BlazorDashboard/BlazorDashboard.csproj
+++ b/sample-applications/blazor-dashboard/BlazorDashboard/BlazorDashboard.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <LangVersion>9</LangVersion>
   </PropertyGroup>
 

--- a/sample-applications/blazor-dashboard/BlazorDashboard/global.json
+++ b/sample-applications/blazor-dashboard/BlazorDashboard/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.100-rc.2",
+    "version": "7.0.0",
     "rollForward": "latestFeature"
   }
 }

--- a/sample-applications/blazor-dashboard/BlazorDashboard/global.json
+++ b/sample-applications/blazor-dashboard/BlazorDashboard/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.100",
+    "version": "7.0.100-rc.2",
     "rollForward": "latestFeature"
   }
 }

--- a/sample-applications/blazor-dashboard/README.md
+++ b/sample-applications/blazor-dashboard/README.md
@@ -17,7 +17,7 @@ To run this app locally, you need:
 
 * Node.js
 * to be able to run the latest Telerik UI for Blazor version (more details [here](https://docs.telerik.com/blazor-ui/getting-started/what-you-need))
-* .NET 6 installed - you can download it from [here](https://dotnet.microsoft.com/download)
+* .NET 7 installed - you can download it from [here](https://dotnet.microsoft.com/download)
 
 If you don't have a commercial license for UI for Blazor, [start a trial](https://www.telerik.com/download-trial-file/v2-b/ui-for-blazor) and replace the package reference with `Telerik.UI.for.Blazor.Trial`.
 

--- a/sample-applications/blazor-stocks/Client/BlazorFinancePortfolio.Client.csproj
+++ b/sample-applications/blazor-stocks/Client/BlazorFinancePortfolio.Client.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
         <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
         <AssemblyName>$(AssemblyName.Replace(' ', '_'))</AssemblyName>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="6.0.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="6.0.0" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="6.0.10" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="6.0.10" PrivateAssets="all" />
         <PackageReference Include="System.Net.Http.Json" Version="5.0.0" />
         <PackageReference Include="System.Net.Http.Json" Version="6.0.0" />
         <PackageReference Include="Telerik.UI.for.Blazor.Trial" Version="3.6.1" />

--- a/sample-applications/blazor-stocks/Client/BlazorFinancePortfolio.Client.csproj
+++ b/sample-applications/blazor-stocks/Client/BlazorFinancePortfolio.Client.csproj
@@ -7,9 +7,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.0-rc.2.22476.2" />
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="7.0.0-rc.2.22476.2" PrivateAssets="all" />
-        <PackageReference Include="System.Net.Http.Json" Version="7.0.0-rc.2.22472.3" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="7.0.0" PrivateAssets="all" />
+        <PackageReference Include="System.Net.Http.Json" Version="7.0.0" />
         <PackageReference Include="Telerik.UI.for.Blazor.Trial" Version="3.6.1" />
         <PackageReference Include="BlazorPro.BlazorSize" Version="3.1.0" />
     </ItemGroup>

--- a/sample-applications/blazor-stocks/Client/BlazorFinancePortfolio.Client.csproj
+++ b/sample-applications/blazor-stocks/Client/BlazorFinancePortfolio.Client.csproj
@@ -7,10 +7,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="6.0.10" />
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="6.0.10" PrivateAssets="all" />
-        <PackageReference Include="System.Net.Http.Json" Version="5.0.0" />
-        <PackageReference Include="System.Net.Http.Json" Version="6.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.0-rc.2.22476.2" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="7.0.0-rc.2.22476.2" PrivateAssets="all" />
+        <PackageReference Include="System.Net.Http.Json" Version="7.0.0-rc.2.22472.3" />
         <PackageReference Include="Telerik.UI.for.Blazor.Trial" Version="3.6.1" />
         <PackageReference Include="BlazorPro.BlazorSize" Version="3.1.0" />
     </ItemGroup>

--- a/sample-applications/blazor-stocks/Server/BlazorFinancePortfolio.Server.csproj
+++ b/sample-applications/blazor-stocks/Server/BlazorFinancePortfolio.Server.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-      <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="6.0.10" />
+      <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="7.0.0-rc.2.22476.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sample-applications/blazor-stocks/Server/BlazorFinancePortfolio.Server.csproj
+++ b/sample-applications/blazor-stocks/Server/BlazorFinancePortfolio.Server.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <DisableImplicitComponentsAnalyzers>true</DisableImplicitComponentsAnalyzers>
   </PropertyGroup>
 
   <ItemGroup>
-      <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="6.0.0-rc.2.21480.10" />
+      <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="6.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sample-applications/blazor-stocks/Server/BlazorFinancePortfolio.Server.csproj
+++ b/sample-applications/blazor-stocks/Server/BlazorFinancePortfolio.Server.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-      <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="7.0.0-rc.2.22476.2" />
+      <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sample-applications/blazor-stocks/Shared/BlazorFinancePortfolio.Shared.csproj
+++ b/sample-applications/blazor-stocks/Shared/BlazorFinancePortfolio.Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/sample-applications/blazor-stocks/global.json
+++ b/sample-applications/blazor-stocks/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.100-rc.2",
+    "version": "7.0.0",
     "rollForward": "latestFeature"
   }
 }

--- a/sample-applications/blazor-stocks/global.json
+++ b/sample-applications/blazor-stocks/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.100",
+    "version": "7.0.100-rc.2",
     "rollForward": "latestFeature"
   }
 }

--- a/sample-applications/blazor-stocks/readme.md
+++ b/sample-applications/blazor-stocks/readme.md
@@ -6,7 +6,7 @@ You may want to review the MSDN article on using the PWA template and working wi
 
 To get the PWA functionality working while testing, you need a "valid" SSL certificate, and the first example from the following Microsoft article can help you generate one for your local machine name, so you can publish the app and test its behavior while developing: https://docs.microsoft.com/en-us/powershell/module/pkiclient/new-selfsignedcertificate?view=win10-ps#examples.
 
-You need to have .NET 6 installed to run the app. You can download it from [here](https://dotnet.microsoft.com/download).
+You need to have .NET 7 installed to run the app. You can download it from [here](https://dotnet.microsoft.com/download).
 
 ## Running the Application
 


### PR DESCRIPTION
**This is a preparation PR where the apps are updated to NET7 RC2. When Microsoft ship the official NET7 version, we'll update them accordingly.** 
Related to: https://github.com/telerik/blazor/issues/4851