### PR TITLE
Update hybrid apps to NET7

### DIFF
--- a/common/hybrid-blazor-apps/BlazorMauiApp/BlazorMauiApp.csproj
+++ b/common/hybrid-blazor-apps/BlazorMauiApp/BlazorMauiApp.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0-android;net6.0-ios;net6.0-maccatalyst</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net6.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks>net7.0-maccatalyst;net7.0-ios;net7.0-android</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net7.0-windows10.0.19041.0</TargetFrameworks>
     <!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
     <!-- <TargetFrameworks>$(TargetFrameworks);net6.0-tizen</TargetFrameworks> -->
     <OutputType>Exe</OutputType>

--- a/common/hybrid-blazor-apps/BlazorWinFormsApp/BlazorWinFormsApp.csproj
+++ b/common/hybrid-blazor-apps/BlazorWinFormsApp/BlazorWinFormsApp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
     <PropertyGroup>
-        <TargetFramework>net6.0-windows</TargetFramework>
+        <TargetFramework>net7.0-windows</TargetFramework>
         <OutputType>WinExe</OutputType>
         <UseWindowsForms>true</UseWindowsForms>
         <IsShippingPackage>false</IsShippingPackage>
@@ -9,7 +9,7 @@
 
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebView.WindowsForms" Version="6.0.312" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebView.WindowsForms" Version="7.0.0-rc.2.6866" />
 
       <!--if you want to try the trial version-->
       <!--<PackageReference Include="Telerik.UI.for.Blazor.Trial" Version="3,3.0" />-->

--- a/common/hybrid-blazor-apps/BlazorWinFormsApp/BlazorWinFormsApp.csproj
+++ b/common/hybrid-blazor-apps/BlazorWinFormsApp/BlazorWinFormsApp.csproj
@@ -9,12 +9,12 @@
 
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebView.WindowsForms" Version="7.0.0-rc.2.6866" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebView.WindowsForms" Version="7.0.49" />
 
       <!--if you want to try the trial version-->
       <!--<PackageReference Include="Telerik.UI.for.Blazor.Trial" Version="3,3.0" />-->
 
-      <PackageReference Include="Telerik.UI.for.Blazor" Version="3.3.0" />
+        <PackageReference Include="Telerik.UI.for.Blazor" Version="3.3.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/common/hybrid-blazor-apps/BlazorWpfApp/BlazorWpfApp.csproj
+++ b/common/hybrid-blazor-apps/BlazorWpfApp/BlazorWpfApp.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Wpf" Version="7.0.0-rc.2.6866" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Wpf" Version="7.0.49" />
 
     <!--if you want to try the trial version-->
     <!--<PackageReference Include="Telerik.UI.for.Blazor.Trial" Version="3.3.0" />-->

--- a/common/hybrid-blazor-apps/BlazorWpfApp/BlazorWpfApp.csproj
+++ b/common/hybrid-blazor-apps/BlazorWpfApp/BlazorWpfApp.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net7.0-windows</TargetFramework>
     <OutputType>WinExe</OutputType>
     <UseWPF>true</UseWPF>
     <IsShippingPackage>false</IsShippingPackage>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Wpf" Version="6.0.312" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Wpf" Version="7.0.0-rc.2.6866" />
 
     <!--if you want to try the trial version-->
     <!--<PackageReference Include="Telerik.UI.for.Blazor.Trial" Version="3.3.0" />-->

--- a/common/hybrid-blazor-apps/WebviewAppShared/WebviewAppShared.csproj
+++ b/common/hybrid-blazor-apps/WebviewAppShared/WebviewAppShared.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <!--<TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>-->
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <!--<ItemGroup>
@@ -10,7 +10,7 @@
   </ItemGroup>-->
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="6.0.0-rc.2.21480.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="7.0.0-rc.2.22476.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/common/hybrid-blazor-apps/WebviewAppShared/WebviewAppShared.csproj
+++ b/common/hybrid-blazor-apps/WebviewAppShared/WebviewAppShared.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>-->
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="7.0.0-rc.2.22476.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
**This is a preparation PR where the apps are updated to NET7 RC2. When Microsoft ship the official NET7 version, we'll update them accordingly.**

Related to: https://github.com/telerik/blazor/issues/5267

TODO:
- ~update Telerik.Blazor to 3.7.0~ will be done separately