### PR TITLE
Changed namespace to assembly reference in responsive charts demo.

### DIFF
--- a/chart/responsive-chart/readme.md
+++ b/chart/responsive-chart/readme.md
@@ -7,7 +7,7 @@ The key points are:
 * When the chart container size changes, you must call its `Refresh()` method.
 * Other useful information is denoted with comments in the code.
 * In this example, a static class is used to dispatch an "event" that comes from the JS Interop (it's perhaps the easiest way to call a C# method from JS).
-* In your actual project you would need to change the JS Interop file to match your namespace.
+* In your actual project you would need to change the JS Interop file to match your assembly name.
 * You can use a similar approach to reach to changes in dimensions coming from other sources, not just JS Interop and browser events.
 
 You can also consider ready-made packages such as [Blazor Size by Ed Charbeneau](https://github.com/EdCharbeneau/BlazorSize)

--- a/chart/responsive-chart/wwwroot/windowResizeHandler.js
+++ b/chart/responsive-chart/wwwroot/windowResizeHandler.js
@@ -1,7 +1,7 @@
 ﻿function raiseResizeEvent() {
-    var namespace = 'ResponsiveChart'; // the namespace of the app, you will have to change this for your app
+    var assemblyName = 'ResponsiveChart'; // the assembly name of the app, you will have to change this for your app
     var method = 'RaiseWindowResizeEvent'; //the name of the method in our "service"
-    DotNet.invokeMethodAsync(namespace, method, Math.floor(window.innerWidth), Math.floor(window.innerHeight));
+    DotNet.invokeMethodAsync(assemblyName, method, Math.floor(window.innerWidth), Math.floor(window.innerHeight));
 }
 
 //throttle resize event, taken from https://stackoverflow.com/a/668185/812369


### PR DESCRIPTION
Changed from namespace to assembly name when using invokeMethodAsync. There is situations when namespace will differ from assembly name.

From Microsoft docs:
DotNet.invokeMethodAsync('{ASSEMBLY NAME}', '{.NET METHOD ID}', {ARGUMENTS});