### PR TITLE
fix: Make base path configuration compatible with Kestrel

### DIFF
--- a/sample-applications/blazing-coffee/BlazingCoffee/Client/Properties/launchSettings.json
+++ b/sample-applications/blazing-coffee/BlazingCoffee/Client/Properties/launchSettings.json
@@ -4,7 +4,6 @@
     "anonymousAuthentication": true,
     "iisExpress": {
       "applicationUrl": "http://localhost:55833/blazor-coffee/",
-      "launchUrl": "",
       "sslPort": 44356
     }
   },

--- a/sample-applications/blazing-coffee/BlazingCoffee/Client/Properties/launchSettings.json
+++ b/sample-applications/blazing-coffee/BlazingCoffee/Client/Properties/launchSettings.json
@@ -19,7 +19,7 @@
     "BlazingCoffee.Server": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "blazor-coffee",
+      "launchUrl": "blazor-coffee/",
       "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
       "applicationUrl": "https://localhost:5001/;http://localhost:5000/",
       "environmentVariables": {

--- a/sample-applications/blazing-coffee/BlazingCoffee/Client/Properties/launchSettings.json
+++ b/sample-applications/blazing-coffee/BlazingCoffee/Client/Properties/launchSettings.json
@@ -3,8 +3,8 @@
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
     "iisExpress": {
-      "applicationUrl": "http://localhost:55833",
-      "launchUrl": "/blazor-coffee/",
+      "applicationUrl": "http://localhost:55833/blazor-coffee/",
+      "launchUrl": "",
       "sslPort": 44356
     }
   },
@@ -17,12 +17,12 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "BlazingCoffee": {
+    "BlazingCoffee.Server": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "/blazor-coffee/",
-      "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/blazor-coffee/_framework/debug/ws-proxy?browser={browserInspectUri}",
-      "applicationUrl": "https://localhost:5001;http://localhost:5000",
+      "launchUrl": "blazor-coffee",
+      "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
+      "applicationUrl": "https://localhost:5001/;http://localhost:5000/",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/sample-applications/blazing-coffee/BlazingCoffee/Client/Properties/launchSettings.json
+++ b/sample-applications/blazing-coffee/BlazingCoffee/Client/Properties/launchSettings.json
@@ -3,7 +3,8 @@
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
     "iisExpress": {
-      "applicationUrl": "http://localhost:55833/blazor-coffee/",
+      "applicationUrl": "http://localhost:55833",
+      "launchUrl": "/blazor-coffee/",
       "sslPort": 44356
     }
   },
@@ -19,8 +20,9 @@
     "BlazingCoffee": {
       "commandName": "Project",
       "launchBrowser": true,
+      "launchUrl": "/blazor-coffee/",
       "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/blazor-coffee/_framework/debug/ws-proxy?browser={browserInspectUri}",
-      "applicationUrl": "https://localhost:5001/blazor-coffee/;http://localhost:5000/blazor-coffee/",
+      "applicationUrl": "https://localhost:5001;http://localhost:5000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/sample-applications/blazing-coffee/BlazingCoffee/Client/wwwroot/index.html
+++ b/sample-applications/blazing-coffee/BlazingCoffee/Client/wwwroot/index.html
@@ -6,7 +6,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <title>Blazing Coffee</title>
     <link href="favicon.ico" rel="icon" type="image/x-icon" />
-    <base href="/blazor-coffee/" />
     <link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet">
     <!-- Trial script file -->
     <!-- If you are using a commercial license, replace the telerik-blazor.js script tag with the one commented below. -->

--- a/sample-applications/blazing-coffee/BlazingCoffee/Server/Data/DbInitializer.cs
+++ b/sample-applications/blazing-coffee/BlazingCoffee/Server/Data/DbInitializer.cs
@@ -1894,7 +1894,7 @@ namespace BlazingCoffee.Server.Data
                 return;
             }
 
-            var importPath = Path.Combine(environment.WebRootPath, @"imports\finserv.csv");
+            var importPath = Path.Combine(environment.WebRootPath, "imports", "finserv.csv");
 
             CultureInfo enUSCulture = new CultureInfo("en-US"); // Fixes data import for non-us users 
             using var reader = new StreamReader(importPath);

--- a/sample-applications/blazing-coffee/BlazingCoffee/Server/Properties/launchSettings.json
+++ b/sample-applications/blazing-coffee/BlazingCoffee/Server/Properties/launchSettings.json
@@ -19,7 +19,7 @@
     "BlazingCoffee.Server": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "blazor-coffee",
+      "launchUrl": "blazor-coffee/",
       "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
       "applicationUrl": "https://localhost:5001/;http://localhost:5000/",
       "environmentVariables": {

--- a/sample-applications/blazing-coffee/BlazingCoffee/Server/Properties/launchSettings.json
+++ b/sample-applications/blazing-coffee/BlazingCoffee/Server/Properties/launchSettings.json
@@ -1,29 +1,31 @@
 {
-    "iisSettings": {
-      "windowsAuthentication": false,
-      "anonymousAuthentication": true,
-      "iisExpress": {
-        "applicationUrl": "http://localhost:55833/blazor-coffee/",
-        "sslPort": 44356
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:55833",
+      "launchUrl": "/blazor-coffee/",
+      "sslPort": 44356
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/blazor-coffee/_framework/debug/ws-proxy?browser={browserInspectUri}",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "profiles": {
-      "IIS Express": {
-        "commandName": "IISExpress",
-        "launchBrowser": true,
-        "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/blazor-coffee/_framework/debug/ws-proxy?browser={browserInspectUri}",
-        "environmentVariables": {
-          "ASPNETCORE_ENVIRONMENT": "Development"
-        }
-      },
-      "BlazingCoffee.Server": {
-        "commandName": "Project",
-        "launchBrowser": true,
-        "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/blazor-coffee/_framework/debug/ws-proxy?browser={browserInspectUri}",
-        "applicationUrl": "https://localhost:5001/blazor-coffee/;http://localhost:5000/blazor-coffee/",
-        "environmentVariables": {
-          "ASPNETCORE_ENVIRONMENT": "Development"
-        }
+    "BlazingCoffee.Server": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "launchUrl": "/blazor-coffee/",
+      "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/blazor-coffee/_framework/debug/ws-proxy?browser={browserInspectUri}",
+      "applicationUrl": "https://localhost:5001;http://localhost:5000",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
       }
     }
   }
+}

--- a/sample-applications/blazing-coffee/BlazingCoffee/Server/Properties/launchSettings.json
+++ b/sample-applications/blazing-coffee/BlazingCoffee/Server/Properties/launchSettings.json
@@ -3,8 +3,7 @@
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
     "iisExpress": {
-      "applicationUrl": "http://localhost:55833",
-      "launchUrl": "/blazor-coffee/",
+      "applicationUrl": "http://localhost:55833/blazor-coffee/",
       "sslPort": 44356
     }
   },
@@ -20,9 +19,9 @@
     "BlazingCoffee.Server": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "/blazor-coffee/",
-      "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/blazor-coffee/_framework/debug/ws-proxy?browser={browserInspectUri}",
-      "applicationUrl": "https://localhost:5001;http://localhost:5000",
+      "launchUrl": "blazor-coffee",
+      "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
+      "applicationUrl": "https://localhost:5001/;http://localhost:5000/",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/sample-applications/blazing-coffee/BlazingCoffee/Server/Startup.cs
+++ b/sample-applications/blazing-coffee/BlazingCoffee/Server/Startup.cs
@@ -47,6 +47,8 @@ namespace BlazingCoffee.Server
                 app.UseHsts();
             }
 
+            app.UsePathBase("/blazor-coffee");
+
             app.UseHttpsRedirection();
             app.UseBlazorFrameworkFiles();
             app.UseStaticFiles();


### PR DESCRIPTION
Triggered by ticket 1605658

The PR also removes the hard-coded `\` separator in the `finserv.csv` path, which is a problem on Unix systems.