### PR TITLE
fix(blazor-coffee): Parse dates when using custom en-US date format

### DIFF
--- a/sample-applications/blazing-coffee/BlazingCoffee/Server/Data/DbInitializer.cs
+++ b/sample-applications/blazing-coffee/BlazingCoffee/Server/Data/DbInitializer.cs
@@ -1896,7 +1896,6 @@ namespace BlazingCoffee.Server.Data
 
             var importPath = Path.Combine(environment.WebRootPath, "imports", "finserv.csv");
 
-            CultureInfo enUSCulture = new CultureInfo("en-US"); // Fixes data import for non-us users 
             using var reader = new StreamReader(importPath);
             using var csv = new CsvReader(reader, CultureInfo.InvariantCulture);
             var records = csv.GetRecords<SalesImportDTO>();
@@ -1913,7 +1912,7 @@ namespace BlazingCoffee.Server.Data
                 Region = dto.Region,
                 StoreId = dto.StoreId,
                 TransactionId = dto.TransactionId,
-                TransactionDate = DateTime.Parse($"{dto.TransactionDate} {dto.TransactionHour}", enUSCulture.DateTimeFormat)
+                TransactionDate = DateTime.ParseExact($"{dto.TransactionDate} {dto.TransactionHour}", "M/d/yyyy H:mm:ss", CultureInfo.InvariantCulture.DateTimeFormat)
             });
 
             context.AddRange(import);


### PR DESCRIPTION
For example, on my machine I have en-US regional settings, but with a custom DateFormat. This leads to an exception about unrecognized format.