### PR TITLE
Remove explicit Resources path

### DIFF
--- a/common/localization/ServerLocalizationResx/Startup.cs
+++ b/common/localization/ServerLocalizationResx/Startup.cs
@@ -34,7 +34,7 @@ namespace ServerLocalizationResx
             #region Localization
 
             services.AddControllers();
-            services.AddLocalization(options => options.ResourcesPath = "Resources");
+            services.AddLocalization();
             services.Configure<RequestLocalizationOptions>(options =>
             {
                 // define the list of cultures your app will support


### PR DESCRIPTION
The explicit Resources path breaks the [Microsoft localization technique with an IStringLocalizer, which is injected without an existing class](https://learn.microsoft.com/en-us/aspnet/core/blazor/globalization-localization?view=aspnetcore-7.0&pivots=server#localization) in a `.razor` file:

```razor
@inject IStringLocalizer<CultureExample2> Loc
```

Our localization doesn't need this setting and works both with and without it.