### PR TITLE
Migrate DPL namespaces in export samples and update to official DPL 2026.3.810

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -82,15 +82,15 @@
     <!-- Telerik (UI + Documents) -->
     <PackageVersion Include="Telerik.UI.for.Blazor" Version="13.1.0" />
     <PackageVersion Include="Telerik.DataSource" Version="4.0.1" />
-    <PackageVersion Include="Telerik.Documents.Core" Version="2026.3.805" />
-    <PackageVersion Include="Telerik.Documents.Fixed" Version="2026.3.805" />
-    <PackageVersion Include="Telerik.Documents.Flow" Version="2026.3.805" />
-    <PackageVersion Include="Telerik.Documents.Flow.FormatProviders.Pdf" Version="2026.3.805" />
-    <PackageVersion Include="Telerik.Documents.ImageUtils" Version="2026.3.805" />
-    <PackageVersion Include="Telerik.Documents.Spreadsheet" Version="2026.3.805" />
-    <PackageVersion Include="Telerik.Documents.Spreadsheet.FormatProviders.OpenXml" Version="2026.3.805" />
-    <PackageVersion Include="Telerik.Documents.Spreadsheet.FormatProviders.Pdf" Version="2026.3.805" />
-    <PackageVersion Include="Telerik.Documents.SpreadsheetStreaming" Version="2026.3.805" />
-    <PackageVersion Include="Telerik.Zip" Version="2026.3.805" />
+    <PackageVersion Include="Telerik.Documents.Core" Version="2026.3.810" />
+    <PackageVersion Include="Telerik.Documents.Fixed" Version="2026.3.810" />
+    <PackageVersion Include="Telerik.Documents.Flow" Version="2026.3.810" />
+    <PackageVersion Include="Telerik.Documents.Flow.FormatProviders.Pdf" Version="2026.3.810" />
+    <PackageVersion Include="Telerik.Documents.ImageUtils" Version="2026.3.810" />
+    <PackageVersion Include="Telerik.Documents.Spreadsheet" Version="2026.3.810" />
+    <PackageVersion Include="Telerik.Documents.Spreadsheet.FormatProviders.OpenXml" Version="2026.3.810" />
+    <PackageVersion Include="Telerik.Documents.Spreadsheet.FormatProviders.Pdf" Version="2026.3.810" />
+    <PackageVersion Include="Telerik.Documents.SpreadsheetStreaming" Version="2026.3.810" />
+    <PackageVersion Include="Telerik.Zip" Version="2026.3.810" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -82,15 +82,15 @@
     <!-- Telerik (UI + Documents) -->
     <PackageVersion Include="Telerik.UI.for.Blazor" Version="13.1.0" />
     <PackageVersion Include="Telerik.DataSource" Version="4.0.1" />
-    <PackageVersion Include="Telerik.Documents.Core" Version="2026.2.724-preview" />
-    <PackageVersion Include="Telerik.Documents.Fixed" Version="2026.2.724-preview" />
-    <PackageVersion Include="Telerik.Documents.Flow" Version="2026.2.724-preview" />
-    <PackageVersion Include="Telerik.Documents.Flow.FormatProviders.Pdf" Version="2026.2.724-preview" />
-    <PackageVersion Include="Telerik.Documents.ImageUtils" Version="2026.2.724-preview" />
-    <PackageVersion Include="Telerik.Documents.Spreadsheet" Version="2026.2.724-preview" />
-    <PackageVersion Include="Telerik.Documents.Spreadsheet.FormatProviders.OpenXml" Version="2026.2.724-preview" />
-    <PackageVersion Include="Telerik.Documents.Spreadsheet.FormatProviders.Pdf" Version="2026.2.724-preview" />
-    <PackageVersion Include="Telerik.Documents.SpreadsheetStreaming" Version="2026.2.724-preview" />
-    <PackageVersion Include="Telerik.Zip" Version="2026.2.724-preview" />
+    <PackageVersion Include="Telerik.Documents.Core" Version="2026.3.805" />
+    <PackageVersion Include="Telerik.Documents.Fixed" Version="2026.3.805" />
+    <PackageVersion Include="Telerik.Documents.Flow" Version="2026.3.805" />
+    <PackageVersion Include="Telerik.Documents.Flow.FormatProviders.Pdf" Version="2026.3.805" />
+    <PackageVersion Include="Telerik.Documents.ImageUtils" Version="2026.3.805" />
+    <PackageVersion Include="Telerik.Documents.Spreadsheet" Version="2026.3.805" />
+    <PackageVersion Include="Telerik.Documents.Spreadsheet.FormatProviders.OpenXml" Version="2026.3.805" />
+    <PackageVersion Include="Telerik.Documents.Spreadsheet.FormatProviders.Pdf" Version="2026.3.805" />
+    <PackageVersion Include="Telerik.Documents.SpreadsheetStreaming" Version="2026.3.805" />
+    <PackageVersion Include="Telerik.Zip" Version="2026.3.805" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -82,15 +82,15 @@
     <!-- Telerik (UI + Documents) -->
     <PackageVersion Include="Telerik.UI.for.Blazor" Version="13.1.0" />
     <PackageVersion Include="Telerik.DataSource" Version="4.0.1" />
-    <PackageVersion Include="Telerik.Documents.Core" Version="2025.3.806" />
-    <PackageVersion Include="Telerik.Documents.Fixed" Version="2025.3.806" />
-    <PackageVersion Include="Telerik.Documents.Flow" Version="2025.3.806" />
-    <PackageVersion Include="Telerik.Documents.Flow.FormatProviders.Pdf" Version="2025.3.806" />
-    <PackageVersion Include="Telerik.Documents.ImageUtils" Version="2025.3.806" />
-    <PackageVersion Include="Telerik.Documents.Spreadsheet" Version="2025.3.806" />
-    <PackageVersion Include="Telerik.Documents.Spreadsheet.FormatProviders.OpenXml" Version="2025.3.806" />
-    <PackageVersion Include="Telerik.Documents.Spreadsheet.FormatProviders.Pdf" Version="2025.3.806" />
-    <PackageVersion Include="Telerik.Documents.SpreadsheetStreaming" Version="2025.3.806" />
-    <PackageVersion Include="Telerik.Zip" Version="2025.3.806" />
+    <PackageVersion Include="Telerik.Documents.Core" Version="2026.2.724-preview" />
+    <PackageVersion Include="Telerik.Documents.Fixed" Version="2026.2.724-preview" />
+    <PackageVersion Include="Telerik.Documents.Flow" Version="2026.2.724-preview" />
+    <PackageVersion Include="Telerik.Documents.Flow.FormatProviders.Pdf" Version="2026.2.724-preview" />
+    <PackageVersion Include="Telerik.Documents.ImageUtils" Version="2026.2.724-preview" />
+    <PackageVersion Include="Telerik.Documents.Spreadsheet" Version="2026.2.724-preview" />
+    <PackageVersion Include="Telerik.Documents.Spreadsheet.FormatProviders.OpenXml" Version="2026.2.724-preview" />
+    <PackageVersion Include="Telerik.Documents.Spreadsheet.FormatProviders.Pdf" Version="2026.2.724-preview" />
+    <PackageVersion Include="Telerik.Documents.SpreadsheetStreaming" Version="2026.2.724-preview" />
+    <PackageVersion Include="Telerik.Zip" Version="2026.2.724-preview" />
   </ItemGroup>
 </Project>

--- a/editor/ImportExport/EditorImportExport/Data/FileConverter.cs
+++ b/editor/ImportExport/EditorImportExport/Data/FileConverter.cs
@@ -4,14 +4,14 @@ using System;
 using System.IO;
 using System.Threading.Tasks;
 using Telerik.Documents.ImageUtils;
-using Telerik.Windows.Documents.Common.FormatProviders;
-using Telerik.Windows.Documents.Extensibility;
-using Telerik.Windows.Documents.Flow.FormatProviders.Pdf;
-using Telerik.Windows.Documents.Flow.FormatProviders.Docx;
-using Telerik.Windows.Documents.Flow.FormatProviders.Html;
-using Telerik.Windows.Documents.Flow.FormatProviders.Rtf;
-using Telerik.Windows.Documents.Flow.FormatProviders.Txt;
-using Telerik.Windows.Documents.Flow.Model;
+using Telerik.Documents.Common.FormatProviders;
+using Telerik.Documents.Extensibility;
+using Telerik.Documents.Flow.FormatProviders.Pdf;
+using Telerik.Documents.Flow.FormatProviders.Docx;
+using Telerik.Documents.Flow.FormatProviders.Html;
+using Telerik.Documents.Flow.FormatProviders.Rtf;
+using Telerik.Documents.Flow.FormatProviders.Txt;
+using Telerik.Documents.Flow.Model;
 
 namespace EditorImportExport.Data
 {
@@ -36,7 +36,7 @@ namespace EditorImportExport.Data
                 HtmlFormatProvider provider = new HtmlFormatProvider();
                 provider.ExportSettings.StylesExportMode = StylesExportMode.Inline;
                 provider.ExportSettings.DocumentExportLevel = DocumentExportLevel.Fragment;
-                string html = provider.Export(document);
+                string html = provider.Export(document, null);
 
                 // get only the <body> contents
                 int bodyStart = html.IndexOf("<body>") + "<body>".Length;
@@ -68,7 +68,7 @@ namespace EditorImportExport.Data
             {
                 // Prepare a document with the HTML content.
                 HtmlFormatProvider provider = new HtmlFormatProvider();
-                RadFlowDocument document = provider.Import(htmlContent);
+                RadFlowDocument document = provider.Import(htmlContent, null);
 
                 // Enable conversion of non-JPG images to JPG.
                 // https://docs.telerik.com/devtools/document-processing/libraries/radpdfprocessing/cross-platform/images
@@ -81,7 +81,7 @@ namespace EditorImportExport.Data
                 byte[]? exportFileBytes = null;
                 using (MemoryStream ms = new MemoryStream())
                 {
-                    exportProvider.Export(document, ms);
+                    exportProvider.Export(document, ms, null);
                     exportFileBytes = ms.ToArray();
                 }
 
@@ -114,7 +114,7 @@ namespace EditorImportExport.Data
 
             using (FileStream input = new FileStream(path, FileMode.Open, FileAccess.Read))
             {
-                document = fileFormatProvider.Import(input);
+                document = fileFormatProvider.Import(input, null);
             }
 
             return document;

--- a/grid/pdf-export-server/PdfExport/RadPdfProcessingExporter.cs
+++ b/grid/pdf-export-server/PdfExport/RadPdfProcessingExporter.cs
@@ -1,17 +1,17 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Diagnostics;
 using System.IO;
-using Telerik.Windows.Documents.Fixed.FormatProviders.Pdf;
-using Telerik.Windows.Documents.Fixed.FormatProviders.Pdf.Export;
-using Telerik.Windows.Documents.Fixed.Model;
-using Telerik.Windows.Documents.Fixed.Model.ColorSpaces;
-using Telerik.Windows.Documents.Fixed.Model.Editing;
-using Telerik.Windows.Documents.Fixed.Model.Editing.Flow;
-using Telerik.Windows.Documents.Fixed.Model.Fonts;
-using Telerik.Windows.Documents.Fixed.Model.Graphics;
-using Telerik.Windows.Documents.Fixed.Model.Editing.Tables;
+using Telerik.Documents.Fixed.FormatProviders.Pdf;
+using Telerik.Documents.Fixed.FormatProviders.Pdf.Export;
+using Telerik.Documents.Fixed.Model;
+using Telerik.Documents.Fixed.Model.ColorSpaces;
+using Telerik.Documents.Fixed.Model.Editing;
+using Telerik.Documents.Fixed.Model.Editing.Flow;
+using Telerik.Documents.Fixed.Model.Fonts;
+using Telerik.Documents.Fixed.Model.Graphics;
+using Telerik.Documents.Fixed.Model.Editing.Tables;
 using System.Threading.Tasks;
 using Telerik.DataSource;
 using Telerik.DataSource.Extensions;
@@ -30,7 +30,7 @@ namespace PdfExport
             byte[] fileBytes = null;
             using (MemoryStream ms = new MemoryStream())
             {
-                provider.Export(document, ms);
+                provider.Export(document, ms, null);
                 fileBytes = ms.ToArray();
             }
 

--- a/grid/pdf-export-server/PdfExport/RadSpreadProcessingExporter.cs
+++ b/grid/pdf-export-server/PdfExport/RadSpreadProcessingExporter.cs
@@ -1,23 +1,24 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Diagnostics;
 using System.IO;
-using Telerik.Windows.Documents.Fixed.FormatProviders.Pdf;
-using Telerik.Windows.Documents.Fixed.FormatProviders.Pdf.Export;
-using Telerik.Windows.Documents.Fixed.Model;
-using Telerik.Windows.Documents.Fixed.Model.ColorSpaces;
-using Telerik.Windows.Documents.Fixed.Model.Editing;
-using Telerik.Windows.Documents.Fixed.Model.Editing.Flow;
-using Telerik.Windows.Documents.Fixed.Model.Fonts;
-using Telerik.Windows.Documents.Fixed.Model.Graphics;
-using Telerik.Windows.Documents.Fixed.Model.Editing.Tables;
-using Telerik.Windows.Documents.Spreadsheet.Model;
+using Telerik.Documents.Fixed.FormatProviders.Pdf;
+using Telerik.Documents.Fixed.FormatProviders.Pdf.Export;
+using Telerik.Documents.Fixed.Model;
+using Telerik.Documents.Fixed.Model.ColorSpaces;
+using Telerik.Documents.Fixed.Model.Editing;
+using Telerik.Documents.Fixed.Model.Editing.Flow;
+using Telerik.Documents.Fixed.Model.Fonts;
+using Telerik.Documents.Fixed.Model.Graphics;
+using Telerik.Documents.Fixed.Model.Editing.Tables;
+using Telerik.Documents.Spreadsheet.Model;
 using Telerik.DataSource;
 using Telerik.DataSource.Extensions;
 using System.Threading.Tasks;
 using System.Reflection;
 using Telerik.Documents.Common.Model;
+using Telerik.Documents.Media;
 
 namespace PdfExport
 {
@@ -44,7 +45,7 @@ namespace PdfExport
             var fieldsList = typeParameterType.GetProperties();
 
             //some styling for the cells - borders in this example
-            ThemableColor black = new ThemableColor(Telerik.Documents.Media.Color.FromArgb(0, 0, 0, 0));
+            ThemableColor black = new ThemableColor(Color.FromArgb(0, 0, 0, 0));
             CellBorders desiredBorders = new CellBorders(
                     new CellBorder(CellBorderStyle.Medium, black),   // Left border 
                     new CellBorder(CellBorderStyle.Medium, black),   // Top border 
@@ -96,12 +97,12 @@ namespace PdfExport
             workbook.ResumeLayoutUpdate();
 
             //convert the excel workbook to a pdf
-            var pdfFormatProvider = new Telerik.Windows.Documents.Spreadsheet.FormatProviders.Pdf.PdfFormatProvider();
+            var pdfFormatProvider = new Telerik.Documents.Spreadsheet.FormatProviders.Pdf.PdfFormatProvider();
 
             byte[] fileBytes = null;
             using (MemoryStream ms = new MemoryStream())
             {
-                pdfFormatProvider.Export(workbook, ms);
+                pdfFormatProvider.Export(workbook, ms, null);
                 fileBytes = ms.ToArray();
             }
 


### PR DESCRIPTION
## Summary
- migrate `Telerik.Windows.*` to `Telerik.Documents.*` in affected export sample files
- update to official 2026.3.810

